### PR TITLE
Adding creation of geo directory before trying to write to the directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ shp/ne_%_admin_1_states_provinces_lakes.shp: zip/ne_%_admin_1_states_provinces_l
 	touch $@
 
 geo/ne_%_us_states.json: shp/ne_%_admin_1_states_provinces.shp
-	rm -f $@ && ogr2ogr -f 'GeoJSON' -where "iso_a2 = ('US')" $@ $<
+	mkdir -p $(dir $@) && rm -f $@ && ogr2ogr -f 'GeoJSON' -where "iso_a2 = ('US')" $@ $<
 
 topo/ne_%_us_states.json: geo/ne_%_us_states.json
 	mkdir -p $(dir $@) && $(TOPOJSON) -q 1e5 --id-property=postal -p name -s 7e-7 -o $@ -- states=$<


### PR DESCRIPTION
Hello there, my colleagues and I have learned a great deal from your tutorials located on http://bost.ocks.org/mike/ and we thank you for writing them.  I have found a bug in the Makefile for the world-atlas repo and would like to bring it to your attention.  Regarding details on the bug I found, while running make for the first time I get the following error.

```
rm -f geo/ne_10m_us_states.json && ogr2ogr -f 'GeoJSON' -where "iso_a2 = ('US')" geo/ne_10m_us_states.json shp/ne_10m_admin_1_states_provinces.shp
ERROR 4: Failed to create GeoJSON datasource: geo/ne_10m_us_states.json.
GeoJSON driver failed to create geo/ne_10m_us_states.json
make: *** [geo/ne_10m_us_states.json] Error 1
```

It appears that the directory named 'geo' needs to be created just before writing the output of the ogr2ogr command to a file inside of it.  This branch attempts to do just that.  I'm looking forward to more of your tutorials and checking out your new projects.  Thank you.
