### PR TITLE
Add instructions to install GDAL to get ogr2ogr binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository provides a convenient mechanism for generating TopoJSON files fr
 
 ## Installing via Homebrew
 
-Before you can run `make`, you’ll need to install Node.js. Here’s how to do that using [Homebrew](http://mxcl.github.com/homebrew/) on Mac OS X:
+Before you can run `make`, you’ll need to install Node.js and `ogr2ogr`. Here’s how to do that using [Homebrew](http://mxcl.github.com/homebrew/) on Mac OS X:
 
 ```bash
-brew install node
+brew install node gdal
 ```
 
 And then, from this repository’s root directory, install the dependencies:


### PR DESCRIPTION
I tried to generate TopoJSON files from Natural Earth using `make`, but I was unable to generate all the files as `ogr2ogr` was not present on my system.

This adds `ogr2ogr` in the install process. I learned how to do that from the Let's Make a Map [step](http://bost.ocks.org/mike/map/#installing-tools).
