### PR TITLE
ensure custom properties propagation

### DIFF
--- a/prepublish
+++ b/prepublish
@@ -15,6 +15,7 @@ world() {
   geo2topo -q 1e5 -n countries=<( \
       shp2json -n build/ne_$1_admin_0_countries.shp \
         | ndjson-map 'i = d.properties.iso_n3, d.id = i === "-99" ? undefined : i, delete d.properties, d' \
+        | ndjson-map 'd.properties = {}, d.properties.id = d.id, d' \ #ensure custom properties propagation
         | geostitch -n) \
     | topomerge land=countries \
     > world/$1.json


### PR DESCRIPTION
Didn't see where the custom properties collection will be kept to propagate by geo2topo into final topojson. This change should ensure such custom properties propagation.