### PR TITLE
Update prepublish for latest upstream data

### DIFF
--- a/prepublish
+++ b/prepublish
@@ -14,13 +14,13 @@ world() {
   mkdir -p world
   geo2topo -q 1e5 -n countries=<( \
       shp2json -n build/ne_$1_admin_0_countries.shp \
-        | ndjson-map 'i = d.properties.iso_n3, d.id = i === "-99" ? undefined : i, delete d.properties, d' \
+        | ndjson-map 'i = d.properties.ISO_N3, d.id = i === "-99" ? undefined : i, delete d.properties, d' \
         | geostitch -n) \
     | topomerge land=countries \
     > world/$1.json
   shp2json -n build/ne_$1_admin_0_countries.shp \
     | ndjson-map 'd.properties' \
-    | ndjson-sort 'a.iso_a3.localeCompare(b.iso_a3)' \
+    | ndjson-sort 'a.ISO_A3.localeCompare(b.ISO_A3)' \
     | json2tsv -n \
     > world/$1.tsv
 }


### PR DESCRIPTION
While attempting to generate a build from the latest upstream Natural Earth data, I noticed all the fields are now upper case. This change makes it so the prepublish script works again, and can be used to publish a new release.

Using these upper case fields would merit a major release, as the TSV header row will change. Alternatively, the script could rename them to lower case for backwards compatibility (not done in this PR).

Closes #24